### PR TITLE
Rename gem name to qasa-url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+*.gem

--- a/lib/qasa/url.rb
+++ b/lib/qasa/url.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "url/version"
+require_relative "../url"
+
+module Qasa
+  module Url
+  end
+end

--- a/lib/qasa/url/version.rb
+++ b/lib/qasa/url/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Qasa
+  module Url
+    VERSION = "0.1.0"
+  end
+end

--- a/qasa-url.gemspec
+++ b/qasa-url.gemspec
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
+require_relative "lib/qasa/url/version"
+
 Gem::Specification.new do |spec|
-  spec.name = "url"
-  spec.version = "0.0.0.rc1"
+  spec.name = "qasa-url"
+  spec.version = Qasa::Url::VERSION
   spec.authors = ["ingemar"]
   spec.email = ["ingemar@xox.se"]
 
-  spec.summary = "A URL parser and constructor that works as you expect"
+  spec.summary = "A simple URL parser and construction tool"
   spec.description = <<~DESC
-    This is a simple URL parser and construction tool for Ruby. It doesn't follow any RFC, instead, it behaves as you expect.
+    URL is a simple URL parser and construction tool for Ruby. It doesn't follow any RFC, instead, it behaves as you expect.
   DESC
-  spec.homepage = "https://github.com/ingemar/url"
+  spec.homepage = "https://github.com/qasase/qasa-url"
   spec.license = "Apache-2.0"
 
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.metadata["allowed_push_host"] = "https://example.com"
+  spec.metadata["allowed_push_host"] = "https://rubygems.or"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"


### PR DESCRIPTION
The gem name `url` is already taken on `rubygems.org`. With this name it can be published.
